### PR TITLE
nem2-cli converter

### DIFF
--- a/src/commands/converter/hextoaddress.ts
+++ b/src/commands/converter/hextoaddress.ts
@@ -19,6 +19,7 @@ import {command, ExpectedError, metadata, option} from 'clime';
 import {ProfileCommand, ProfileOptions} from '../../profile.command';
 import {OptionsResolver} from "../../options-resolver";
 import {Address} from "nem2-sdk";
+import {MonitorAddressOptions} from "../../monitor.transaction.command";
 
 export class CommandOptions extends ProfileOptions {
     @option({
@@ -37,15 +38,14 @@ export default class extends ProfileCommand {
     }
 
     @metadata
-    execute(options: ProfileOptions) {
-
-        const address  = OptionsResolver(options,
-            'address',
-            () => undefined,
-            'Introduce the  a hexadecimal address : ');
+    execute(options: MonitorAddressOptions) {
         try {
-            const addressRst = Address.createFromRawAddress(address);
-            console.log(addressRst);
+            const address = Address.createFromRawAddress(
+                OptionsResolver(options,
+                    'address',
+                    () => undefined,
+                    'Introduce the address: '));
+            console.log(address);
         } catch (err) {
             throw new ExpectedError('introduce a valid address');
         }

--- a/src/commands/converter/hextoaddress.ts
+++ b/src/commands/converter/hextoaddress.ts
@@ -1,0 +1,53 @@
+/*
+ *
+ * Copyright 2018 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import {command, ExpectedError, metadata, option} from 'clime';
+import {ProfileCommand, ProfileOptions} from '../../profile.command';
+import {OptionsResolver} from "../../options-resolver";
+import {Address} from "nem2-sdk";
+
+export class CommandOptions extends ProfileOptions {
+    @option({
+        flag: 'd',
+        description: ' a hexadecimal address  ',
+    })
+    address: string;
+}
+@command({
+    description: 'Converts a hexadecimal address to an address',
+})
+export default class extends ProfileCommand {
+
+    constructor() {
+        super();
+    }
+
+    @metadata
+    execute(options: ProfileOptions) {
+
+        const address  = OptionsResolver(options,
+            'address',
+            () => undefined,
+            'Introduce the  a hexadecimal address : ');
+        try {
+            const addressRst = Address.createFromRawAddress(address);
+            console.log(addressRst);
+        } catch (err) {
+            throw new ExpectedError('introduce a valid address');
+        }
+    }
+}

--- a/src/commands/converter/hextouint.ts
+++ b/src/commands/converter/hextouint.ts
@@ -1,0 +1,53 @@
+/*
+ *
+ * Copyright 2018 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import {command, ExpectedError, metadata, option} from 'clime';
+import {ProfileCommand, ProfileOptions} from '../../profile.command';
+import {OptionsResolver} from "../../options-resolver";
+import {Id} from "nem2-sdk";
+
+export class CommandOptions extends ProfileOptions {
+    @option({
+        flag: 'i',
+        description: ' a hexadecimal id  ',
+    })
+    id: string;
+}
+
+@command({
+    description: 'Converts a hexadecimal id to a uint64 object',
+})
+export default class extends ProfileCommand {
+
+    constructor() {
+        super();
+    }
+    @metadata
+    execute(options: ProfileOptions) {
+
+        const id  = OptionsResolver(options,
+            'id',
+            () => undefined,
+            'Introduce the  a hexadecimal id : ');
+        try {
+            const rst =  Id.fromHex(id);
+            console.log(rst);
+        } catch (err) {
+            throw new ExpectedError('introduce a valid id');
+        }
+    }
+}

--- a/src/commands/converter/uinttohex.ts
+++ b/src/commands/converter/uinttohex.ts
@@ -1,0 +1,53 @@
+/*
+ *
+ * Copyright 2018 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import {command, ExpectedError, metadata, option} from 'clime';
+import {ProfileCommand, ProfileOptions} from '../../profile.command';
+import {OptionsResolver} from "../../options-resolver";
+import {Id, Mosaic, MosaicId} from "nem2-sdk";
+
+export class CommandOptions extends ProfileOptions {
+    @option({
+        flag: 'm',
+        description: ' a hexadecimal mosaic  ',
+    })
+    mosaic: string;
+}
+
+@command({
+    description: 'Converts a hexadecimal mosaic to a uint64 object',
+})
+export default class extends ProfileCommand {
+
+    constructor() {
+        super();
+    }
+    @metadata
+    execute(options: ProfileOptions) {
+
+        const mosaic  = OptionsResolver(options,
+            'mosaic',
+            () => undefined,
+            'Introduce the  a hexadecimal mosaic : ');
+        try {
+            const rst =  new MosaicId(mosaic);
+            console.log(rst);
+        } catch (err) {
+            throw new ExpectedError('introduce a valid mosaic');
+        }
+    }
+}

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -35,6 +35,10 @@ export const subcommands = [
         brief: 'Fetch blockchain information',
     },
     {
+        name: 'converter',
+        brief: 'converter tools',
+    },
+    {
         name: 'mosaic',
         brief: 'Fetch mosaic information',
     },


### PR DESCRIPTION
nem2-cli converter

SUBCOMMANDS

hextoaddress - Converts a hexadecimal address to an address
hextouint - Converts a hexadecimal id to a uint64 object
uinttohex- Converts a hexadecimal mosaic to a uint64 object